### PR TITLE
Use substring instead of replace()

### DIFF
--- a/lib/consumed.js
+++ b/lib/consumed.js
@@ -4,7 +4,7 @@
   };
 
   Consumed.prototype._updateString = function(replacement) {
-    this.str = this.str.replace(replacement, '');
+    this.str = this.str.substring(replacement.length);
   };
 
   Consumed.prototype.consumeTill = function(c, inclusive) {


### PR DESCRIPTION
Hi! This is a very silly question, so feel free to ignore.

I'm just curious why you don't use substring; wouldn't [that be faster](https://jsperf.com/substr-vs-substring-vs-replace)? Since replace() has to compare the characters again. :)